### PR TITLE
pass context to use

### DIFF
--- a/lucius-polymer.js
+++ b/lucius-polymer.js
@@ -47,12 +47,12 @@ function lucius(opts) {
     return this
   }
 
-  function use (t) {
+  function use (t, context) {
     if (!(t instanceof Function)) {
       throw Error('transport must be a function')
     }
     transports.push(function (args, cb) {
-      t(args, cb || function (err) {
+      t.call(context || this, args, cb || function (err) {
         if (err) {
           console.error('Lucius error:', err)
         }


### PR DESCRIPTION
When "use" is called within the context of a component, allows us to call component member functions when the transport is triggered.

`is: ':role',
  ready: function () {
    var cmp = this
    cmp.use(cmp.transport,cmp);
  },
  transport: function (args, cb) {
    console.log('args',args);
    var cmp = this;
        cmp.customLookup(args, function (err, response) {
            if (err) { return cb(err) }
            if (!response) { //no match!
                err = Error('no matching pattern')
                err.code = 404
                cb && cb(err)
                return
            }
            cb(null, response)
        })
    },
    customLookup: function (args, cb) {
        console.log('just testing we got here.');
        cb('customLookup error');
    },`
